### PR TITLE
Change the scale+transform figures for the london map

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -78,7 +78,7 @@
       t;
 
     if (PetitionMap.current_area === "lon") {
-      t = [((width - s * (b[1][0] + b[0][0])) / 2.25), (height - s * (b[1][1] + b[0][1])) / 2];
+      t = [((width - s * (b[1][0] + b[0][0])) / 2.00), (height - s * (b[1][1] + b[0][1])) / 2];
     } else if (PetitionMap.current_area === "uk") {
       t = [((width - s * (b[1][0] + b[0][0])) / 1.95), (height - s * (b[1][1] + b[0][1])) / 2];
     } else {


### PR DESCRIPTION
The 2.25 figure was pushing the london map to the right of the map area, but using 2.00 seems to get it back nearer the centre.  Totally unsure why we have to mess with the transform at all tbh, or why it's different for lon, gb, others.
