### PR TITLE
Class name is LabourCooperative not LabourCoop

### DIFF
--- a/css/party_colours.css
+++ b/css/party_colours.css
@@ -10,7 +10,7 @@
 .Labour {
   fill: #DC241f;
 }
-.LabourCoop {
+.LabourCooperative {
   fill: #CC0000;
 }
 .LiberalDemocrat {

--- a/js/map.js
+++ b/js/map.js
@@ -22,7 +22,7 @@
       "GreenParty",
       "Independent",
       "Labour",
-      "LabourCoop",
+      "LabourCooperative",
       "LiberalDemocrat",
       "PlaidCymru",
       "ScottishNationalParty",


### PR DESCRIPTION
Rollover colour wasn't being applied correctly because it wasn't the correct CSS class name.
