### PR TITLE
Define CSS styles for areas in the 0th bucket

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -23,20 +23,12 @@
   stroke-width: 1;
 }
 
-.c1 { fill: #fed976; }
-.c2 { fill: #feb24c; }
-.c3 { fill: #fd8d3c; }
-.c4 { fill: #fc4e2a; }
-.c5 { fill: #e31a1c; }
-.c6 { fill: #b10026; }
-.c7 { fill: #8d001e; }
-.c8 { fill: #6a0016; }
-
-.t1 { color: #fed976; }
-.t2 { color: #feb24c; }
-.t3 { color: #fd8d3c; }
-.t4 { color: #fc4e2a; }
-.t5 { color: #e31a1c; }
-.t6 { color: #b10026; }
-.t7 { color: #8d001e; }
-.t8 { color: #6a0016; }
+.c0 { fill: #C0C0C0; color: #C0C0C0; }
+.c1 { fill: #fed976; color: #fed976; }
+.c2 { fill: #feb24c; color: #feb24c; }
+.c3 { fill: #fd8d3c; color: #fd8d3c; }
+.c4 { fill: #fc4e2a; color: #fc4e2a; }
+.c5 { fill: #e31a1c; color: #e31a1c; }
+.c6 { fill: #b10026; color: #b10026; }
+.c7 { fill: #8d001e; color: #8d001e; }
+.c8 { fill: #6a0016; color: #6a0016; }

--- a/index.html
+++ b/index.html
@@ -80,39 +80,39 @@
             <section id="key" hidden>
                 <table>
                     <tr>
-                        <td class="area">&#9608;</td>
+                        <td class="c0">&#9608;</td>
                         <td>0</td>
                     </tr>
                     <tr>
-                        <td class="t1">&#9608;</td>
+                        <td class="c1">&#9608;</td>
                         <td id="t1"></td>
                     </tr>
                     <tr>
-                        <td class="t2">&#9608;</td>
+                        <td class="c2">&#9608;</td>
                         <td id="t2"></td>
                     </tr>
                     <tr>
-                        <td class="t3">&#9608;</td>
+                        <td class="c3">&#9608;</td>
                         <td id="t3"></td>
                     </tr>
                     <tr>
-                        <td class="t4">&#9608;</td>
+                        <td class="c4">&#9608;</td>
                         <td id="t4"></td>
                     </tr>
                     <tr>
-                        <td class="t5">&#9608;</td>
+                        <td class="c5">&#9608;</td>
                         <td id="t5"></td>
                     </tr>
                     <tr>
-                        <td class="t6">&#9608;</td>
+                        <td class="c6">&#9608;</td>
                         <td id="t6"></td>
                     </tr>
                     <tr>
-                        <td class="t7">&#9608;</td>
+                        <td class="c7">&#9608;</td>
                         <td id="t7"></td>
                     </tr>
                     <tr>
-                        <td class="t8">&#9608;</td>
+                        <td class="c8">&#9608;</td>
                         <td id="t8"></td>
                     </tr>
                 </table>
@@ -208,7 +208,7 @@
               Contains LPS Intellectual Property Crown copyright and database right [2015]. This information is licensed under the terms of the Open Government Licence.
           </p>
           <p>
-              The estimated (mid-2014) population data for each constituency is sourced from the 
+              The estimated (mid-2014) population data for each constituency is sourced from the
               <a href="http://www.nisra.gov.uk/demography/default.asp41.htm">Northern Ireland Statistics and Research Agency</a>, the <a href="http://www.nrscotland.gov.uk/statistics-and-data/statistics/statistics-by-theme/population/population-estimates/special-area-population-estimates/ukpc-population-estimates">National Records of Scotland</a>, and the <a href="https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/populationestimates/datasets/parliamentaryconstituencymidyearpopulationestimates">Office for National Statistics</a>.
           </p>
         </div>


### PR DESCRIPTION
When no-one in a constituency signs a petition usually the constituency does
not appear in the JSON signatures_by_constituency payload so we did not need
to have a CSS selector for entries in the 0th bucket because we wouldn't assign
anything to it.  However, in rare cases (fraud removal usually) the constituency
can appear in the JSON and without a CSS selector they get a full black fill.

We also remove the t1-t8 classes used for the key, as we can re-use the c0-c8
classes here and not run the risk of the colouring for the key and
constituencies getting out of sync.